### PR TITLE
Feature/sentry update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project does adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require sentry/sentry-laravel
 - Swagger Model Update for ArticleBundles
 
+## [2.2.1] - 2022-12-12
+### Changed
+- Update sentry/sentry-laravel to v3
+
 ## [2.2.0] - 2022-11-11
 ### Added
 - Add withhold_import origin status

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "php": ">=7.1",
     "guzzlehttp/guzzle": "^7.2|^6.2",
     "moneyphp/money": "^3.0",
-    "illuminate/support": ">=5.5"
+    "illuminate/support": ">=5.5",
+    "sentry/sentry-laravel": "^3.0.0"
   },
   "require-dev": {
   },

--- a/src/LaravelClient.php
+++ b/src/LaravelClient.php
@@ -33,7 +33,9 @@ class LaravelClient extends Client
         }
 
         try {
-            app('sentry')->captureException($e, ['extra' => $context]);
+            $hint        = new Sentry\EventHint();
+            $hint->extra = $context;
+            app('sentry')->captureException($e, $hint);
         }
         catch (\Exception $e) {
         }

--- a/src/LaravelClient.php
+++ b/src/LaravelClient.php
@@ -4,6 +4,7 @@ namespace SSB\Api;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
+use Sentry\EventHint;
 
 class LaravelClient extends Client
 {
@@ -32,15 +33,12 @@ class LaravelClient extends Client
             }
         }
 
-        try {
-            $hint = ['extra' => $context];
-            if (class_exists('Sentry\EventHint')) {
-                $hint        = new Sentry\EventHint();
-                $hint->extra = $context;
-            }
+        if (app()->bound('sentry')) {
+            $hint        = new EventHint();
+            $hint->extra = $context;
             app('sentry')->captureException($e, $hint);
-        }
-        catch (\Exception $e) {
+        } else {
+            report($e);
         }
     }
 

--- a/src/LaravelClient.php
+++ b/src/LaravelClient.php
@@ -33,8 +33,11 @@ class LaravelClient extends Client
         }
 
         try {
-            $hint        = new Sentry\EventHint();
-            $hint->extra = $context;
+            $hint = ['extra' => $context];
+            if (class_exists('Sentry\EventHint')) {
+                $hint        = new Sentry\EventHint();
+                $hint->extra = $context;
+            }
             app('sentry')->captureException($e, $hint);
         }
         catch (\Exception $e) {


### PR DESCRIPTION
Reishunger erhält derzeit keine Exceptions vom Client, da dieser nicht kompatibel zu Sentry v3 ist. Stattdessen erhalten wir Exceptions vom Exception Handling.

Ich habe hier einen Vorschlag vorbereitet. Ich kann aber nicht compilen. Dementsprechend ist es auch nicht getestet.

Mir ist aufgefallen, dass Sentry hier gar nicht in composer geführt wird, aber auch nicht auf Existenz geprüft wird. Ist das gewollt?